### PR TITLE
adjusted hamburger button and page-name on mobile view

### DIFF
--- a/client/src/components/Navbar/sideMenu.css
+++ b/client/src/components/Navbar/sideMenu.css
@@ -151,7 +151,8 @@ nav li:hover{
     background: transparent;
     border: 0px;
     margin: 0;
-
+    text-align: left;
+    padding-left: 1rem;
 }
 .crosbtn{
     background: transparent;
@@ -159,7 +160,11 @@ nav li:hover{
     margin: 0;
 }
 .hamburg{
-    display: inline;
+    display: flex;
+}
+
+.hamburg img{
+    padding-left: 0;
 }
 
 .mobmen{
@@ -176,10 +181,11 @@ nav li:hover{
     margin: 0;
 }
 .Nav-menu{
-    
     width: 100vw;
-   
 }
 
+.page-name h3 {
+    margin-left: -3.5rem;
+}
 
 }


### PR DESCRIPTION
- adjusted hamburger button
- added -3.5 margin left on page-name 

after styling
<img width="356" alt="image" src="https://user-images.githubusercontent.com/103476551/203482942-c220fec1-7d54-4d92-a35d-f5b6f575c7ed.png">


---desktop not affected
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/103476551/203483129-7de53000-b52d-460d-8098-2118d92e29ef.png">

